### PR TITLE
Add MongoDB into Travis' backend test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 matrix:
   include:  
   - language: node_js
+    services: mongodb
     node_js:
     - "stable"
     cache:

--- a/server/src/config/mongodb.ts
+++ b/server/src/config/mongodb.ts
@@ -3,9 +3,14 @@ import dotenv from 'dotenv'
 
 dotenv.config()
 
+const mongoHost =
+    process.env.NODE_ENV == 'production'
+        ? `mongodb+srv://${process.env.DB_USER}:` +
+          `${process.env.DB_PASS}@${process.env.DB_HOST}`
+        : `mongodb://localhost/`
+
 const mongoUrl =
-    `mongodb+srv://${process.env.DB_USER}:` +
-    `${process.env.DB_PASS}@${process.env.DB_HOST}` +
+    mongoHost +
     `${process.env.DB_NAME}_${process.env.NODE_ENV}?retryWrites=true&w=majority`
 
 export const connectToDatabase = (): void => {


### PR DESCRIPTION
Now test runs using MongoDB within the Travis build instead of an MongoDB Atlas connection